### PR TITLE
feat: Implemented a new `_prepare_images` helper that converts file paths, tensors, and image lists to PIL images

### DIFF
--- a/pipeline_metaquery.py
+++ b/pipeline_metaquery.py
@@ -27,16 +27,15 @@ class MetaQueryPipeline(MetaQuery):
 
     def _load_image(self, img: Union[str, Image.Image, torch.Tensor, np.ndarray],) -> Image.Image:
         """
-        Normalise a image into a fresh ``PIL.Image`` (RGB / RGBA / L).
+        Normalize various image inputs to a RGB ``PIL.Image``.
 
-        Accepts
-        --------
-        - str             : local / remote path
-        - PIL.Image       : any mode, auto-converted to RGB
-        - torch.Tensor    : (H, W) or (C, H, W) with 1 / 3 / 4 channels
-        - np.ndarray      : same shapes as tensor input
+        Supported inputs are:
+            - ``str``: path to an image (local or remote)
+            - ``PIL.Image``: any mode, converted to RGB
+            - ``torch.Tensor``: ``(H, W)`` or ``(C, H, W)`` with 1/3/4 channels
+            - ``np.ndarray``: same shapes as ``torch.Tensor`` input
 
-        Any other shape or dtype raises ``TypeError``.
+        Any floating values are assumed in ``[0,1]`` and scaled to ``uint8``.
         """
         if isinstance(img, Image.Image):
             return img.convert("RGB")
@@ -106,6 +105,7 @@ class MetaQueryPipeline(MetaQuery):
                 List[Union[Image.Image, str, torch.Tensor, List[Union[Image.Image, str, torch.Tensor]]]],
                 torch.Tensor,
                 List[torch.Tensor],
+                np.ndarray,
             ]
         ] = None,
         negative_prompt: Optional[str] = "",

--- a/pipeline_metaquery.py
+++ b/pipeline_metaquery.py
@@ -80,10 +80,10 @@ class MetaQueryPipeline(MetaQuery):
         def convert(elem):
             if elem is None:
                 return None
-            if isinstance(elem, Sequence) and not isinstance(elem, (str, bytes, bytearray)):
-                return [convert(e) for e in elem]
             if isinstance(elem, (str, Image.Image, torch.Tensor, np.ndarray)):
                 return self._load_image(elem)
+            if isinstance(elem, Sequence) and not isinstance(elem, (str, bytes, bytearray)):
+                return [convert(e) for e in elem]
             raise TypeError(f"Unsupported image input type: {type(elem)}")
         return None if images is None else convert(images)
 

--- a/pipeline_metaquery.py
+++ b/pipeline_metaquery.py
@@ -76,16 +76,12 @@ class MetaQueryPipeline(MetaQuery):
         raise TypeError(f"Unsupported image type: {type(img)}")
 
     def _prepare_images(self, images):
-        """
-        Walk an arbitrarily nested structure (list / tuple) and convert every leaf image to ``PIL.Image`` without altering the outer shape.
-
-        `None` is left untouched so the caller can decide how to use it.
-        """
+        """Recursively convert nested image structures to lists of ``PIL.Image`` leaves."""
         def convert(elem):
             if elem is None:
                 return None
             if isinstance(elem, Sequence) and not isinstance(elem, (str, bytes, bytearray)):
-                return elem.__class__(convert(e) for e in elem)
+                return [convert(e) for e in elem]
             if isinstance(elem, (str, Image.Image, torch.Tensor, np.ndarray)):
                 return self._load_image(elem)
             raise TypeError(f"Unsupported image input type: {type(elem)}")

--- a/pipeline_metaquery.py
+++ b/pipeline_metaquery.py
@@ -4,21 +4,20 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Union, List
-from typing import Tuple
+from typing import Optional, Union, List, Tuple
+from collections.abc import Sequence
 
 import torch
 from PIL import Image
 from diffusers.pipelines.pipeline_utils import BaseOutput
 import numpy as np
-import PIL
 from dataclasses import dataclass
 from models.metaquery import MetaQuery
 
 
 @dataclass
 class MetaQueryPipelineOutput(BaseOutput):
-    images: Union[List[PIL.Image.Image], np.ndarray]
+    images: Union[List[Image.Image], np.ndarray]
     # text: Optional[List[str]] = [""]
 
 
@@ -26,12 +25,84 @@ class MetaQueryPipeline(MetaQuery):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def _load_image(self, img: Union[str, Image.Image, torch.Tensor, np.ndarray],) -> Image.Image:
+        """
+        Normalise a image into a fresh ``PIL.Image`` (RGB / RGBA / L).
+
+        Accepts
+        --------
+        - str             : local / remote path
+        - PIL.Image       : any mode, auto-converted to RGB
+        - torch.Tensor    : (H, W) or (C, H, W) with 1 / 3 / 4 channels
+        - np.ndarray      : same shapes as tensor input
+
+        Any other shape or dtype raises ``TypeError``.
+        """
+        if isinstance(img, Image.Image):
+            return img.convert("RGB")
+        if isinstance(img, str):
+            return Image.open(img).convert("RGB")
+        if isinstance(img, np.ndarray):
+            arr = img
+            if arr.ndim == 2:
+                return Image.fromarray(arr.astype(np.uint8), mode="L").convert("RGB")
+            if arr.ndim == 3:
+                h, w, c = arr.shape
+                if c == 1:
+                    arr = arr.squeeze(-1)
+                    return Image.fromarray(arr.astype(np.uint8), mode="L").convert("RGB")
+                if c in (3, 4):
+                    return Image.fromarray(arr.astype(np.uint8))
+            raise TypeError(f"Unsupported numpy shape: {arr.shape}")
+        if isinstance(img, torch.Tensor):
+            t = img.detach().cpu()
+            if t.dim() == 2:
+                if t.is_floating_point():
+                    t = (t.clamp(0, 1) * 255)
+                return Image.fromarray(t.to(torch.uint8).numpy(), mode="L").convert("RGB")
+            if t.dim() == 3:
+                if t.is_floating_point():
+                    t = (t.clamp(0, 1) * 255)
+                t = t.to(torch.uint8)
+                c = t.shape[0]
+                if c == 1:
+                    arr = t.squeeze(0).numpy()
+                    return Image.fromarray(arr, mode="L").convert("RGB")
+                if c in (3, 4):
+                    arr = t.permute(1, 2, 0).numpy()
+                    mode = "RGB" if c == 3 else "RGBA"
+                    return Image.fromarray(arr, mode=mode)
+            raise TypeError(f"Unsupported tensor shape: {t.shape}")
+        raise TypeError(f"Unsupported image type: {type(img)}")
+
+    def _prepare_images(self, images):
+        """
+        Walk an arbitrarily nested structure (list / tuple) and convert every leaf image to ``PIL.Image`` without altering the outer shape.
+
+        `None` is left untouched so the caller can decide how to use it.
+        """
+        def convert(elem):
+            if elem is None:
+                return None
+            if isinstance(elem, Sequence) and not isinstance(elem, (str, bytes, bytearray)):
+                return elem.__class__(convert(e) for e in elem)
+            if isinstance(elem, (str, Image.Image, torch.Tensor, np.ndarray)):
+                return self._load_image(elem)
+            raise TypeError(f"Unsupported image input type: {type(elem)}")
+        return None if images is None else convert(images)
+
     @torch.no_grad()
     def __call__(
         self,
         caption: Optional[str] = "",
         image: Optional[
-            Union[Image.Image, List[Image.Image], torch.Tensor, List[torch.Tensor]]
+            Union[
+                Image.Image,
+                str,
+                List[Union[Image.Image, str, torch.Tensor, List[Union[Image.Image, str, torch.Tensor]]]],
+                torch.Tensor,
+                List[torch.Tensor],
+            ]
         ] = None,
         negative_prompt: Optional[str] = "",
         guidance_scale: float = 7.5,
@@ -43,9 +114,11 @@ class MetaQueryPipeline(MetaQuery):
         **kwargs,
     ) -> Union[MetaQueryPipelineOutput, Tuple]:
 
+        images = self._prepare_images(image)
+
         samples = self.sample_images(
             caption=caption,
-            input_images=image,
+            input_images=images,
             negative_prompt=negative_prompt,
             guidance_scale=guidance_scale,
             image_guidance_scale=image_guidance_scale,

--- a/pipeline_metaquery.py
+++ b/pipeline_metaquery.py
@@ -25,7 +25,7 @@ class MetaQueryPipeline(MetaQuery):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _load_image(self, img: Union[str, Image.Image, torch.Tensor, np.ndarray],) -> Image.Image:
+    def _load_image(self, img: Union[str, Image.Image, torch.Tensor, np.ndarray]) -> Image.Image:
         """
         Normalize various image inputs to a RGB ``PIL.Image``.
 


### PR DESCRIPTION
Changes:
- Introduced a new `_prepare_images` helper that converts file paths, tensors, and image lists to PIL images, enabling more flexible input handling in the pipeline.
- The pipeline now recursively converts image inputs while preserving their nested structure, ensuring compatibility with the underlying sampler.
- `__call__` prepares these normalized images before delegating to `sample_images`.

Why these changes?
- Passing a file path or numpy array would raise a TypeError because `sample_images` expects PIL images and performs operations like `img.size` though users are expected to give proper image but still.
- The new helpers automatically normalize inputs, allowing callers to provide images as file paths, tensors, numpy arrays, or nested lists thereof. This makes the pipeline easier to use and prevents runtime errors when the inputs are not already PIL images.